### PR TITLE
Optimize Redundant Sender Validation in ERC20 transfer Function

### DIFF
--- a/src/ERC7629.sol
+++ b/src/ERC7629.sol
@@ -484,11 +484,6 @@ abstract contract ERC7629 is IERC7629 {
      * @notice Prevents burning tokens to address(0).
      */
     function transfer(address to, uint256 amount) external returns (bool) {
-        // Prevent burning tokens to 0x0.
-        if (to == address(0)) {
-            revert ERC20InvalidReceiver(to);
-        }
-
         _transferERC20(msg.sender, to, amount);
         return true;
     }


### PR DESCRIPTION
**Description**:

This PR simplifies the transfer function of the ERC7629 contract by removing a redundant check for the validity of the sender address. The check is already performed in the `_transferERC20` internal function, which is called by `transfer`.

Previously, the `transfer` function included a check to prevent burning tokens by transferring to the `0x0` address and may revert an `ERC20InvalidSender`. However, this validation is unnecessary because `_transferERC20` also performs this check. By removing the redundant check in the `transfer` function, we reduce code duplication and gas costs for users.

The `ERC20InvalidSender` checking in `_transferERC20` in line 371:
![image](https://github.com/ColorfuLabs/ERC7629/assets/47737641/4ec7d365-17fb-47e3-bd95-c5f632b0b643)

**Changes**:

Removed the conditional check for the to address against `address(0)` in the transfer function.
Relied on the `_transferERC20` function to handle the validation of both from and to addresses.

**Benefits**:

- Gas optimization: Less execution and validation logic leads to lower gas fees for the end user when performing transfers.

- Code maintainability: Having a single point of validation for sender and receiver addresses reduces the potential for discrepancies and simplifies future updates to the contract.

- Adherence to DRY principles: The "Don't Repeat Yourself" principle is better upheld, avoiding duplicated logic across contract functions.

This update is expected to enhance the contract's performance and maintainability without affecting the security or functionality of token transfers.