### PR TITLE
🐞Bugfix on erc20ToERC721

### DIFF
--- a/src/ERC7629.sol
+++ b/src/ERC7629.sol
@@ -866,7 +866,7 @@ abstract contract ERC7629 is IERC7629 {
             tokenIds[i] = tokenId;
         }
 
-        uint256 tokenCount = _erc721BalanceOf(msg.sender);
+        uint256 tokenCount = _erc721BalanceOf(address(this));
         for (uint256 i = 0; i < nftTransferAmount; i++) {
             uint256 tokenId = _getTokenIdAtIndex(address(this), tokenCount - i - 1);
             _updateERC721(msg.sender, tokenId);


### PR DESCRIPTION
**Description**:

The recent `erc20ToERC721(uint256)` function gets the `tokenId` by `index` caculated with `msg.sender`'s balance instead of `address(this)`'s balance. Unwanted behavior will occur once the balance of the `msg.sender` is lesser than the `nftTransferAmount`.